### PR TITLE
Add support for directory uploading

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.0.1"
+version = "1.1.0"
 
 repositories {
   mavenLocal()
@@ -38,7 +38,7 @@ dependencies {
   implementation("org.postgresql:postgresql:42.3.6")
 
   // S3
-  implementation("org.veupathdb.lib.s3:s34k-minio:0.3.2+s34k-0.7.0")
+  implementation("org.veupathdb.lib.s3:s34k-minio:0.3.3+s34k-0.7.1")
   implementation("org.veupathdb.lib.s3:workspaces:4.0.3")
 
   // Rabbit


### PR DESCRIPTION
### Description

Adds support for uploading directories of files on job completion.

Empty directories will not be persisted.

Job completion could mean either success or failure.

Closes #17 

### Changes
- bump version to 1.1.0
- update dependency on s34k-minio
- add directory upload support

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies