### PR TITLE
Record job output files in DB.

### DIFF
--- a/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
+++ b/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
@@ -103,6 +103,11 @@ internal object QueueDB {
     ds!!.connection.use { MarkJobFinished(it, jobID, JobStatus.Failed) }
   }
 
+  @JvmStatic
+  fun setJobOutputFiles(jobID: HashID, files: Array<String>) {
+    Log.debug("Appending output files to job {}", jobID)
+    ds!!.connection.use { SetJobOutputFiles(it, jobID, files) }
+  }
 
   /**
    * Marks the target job as completed in the database.

--- a/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/update/append-out-files.kt
+++ b/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/update/append-out-files.kt
@@ -1,0 +1,22 @@
+package org.veupathdb.lib.compute.platform.intern.db.queries.update
+
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+
+private const val SQL = """
+  UPDATE
+    compute.jobs
+  SET
+    output_files = ?
+  WHERE
+    job_id = ?
+"""
+
+internal fun SetJobOutputFiles(con: Connection, jobID: HashID, files: Array<String>) {
+  con.prepareStatement(SQL).use {
+    it.setArray(1, con.createArrayOf("VARCHAR", files))
+    it.setBytes(2, jobID.bytes)
+    it.execute()
+  }
+}
+

--- a/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/jobs/JobExecutionHandler.kt
+++ b/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/jobs/JobExecutionHandler.kt
@@ -88,6 +88,9 @@ internal class JobExecutionHandler(private val executor: JobExecutor) {
       // Persist the outputs of the job to S3.
       S3.persistFiles(jobID, workspace.getFiles(res.outputFiles))
 
+      // Record the output files on the job row
+      QueueDB.setJobOutputFiles(jobID, res.outputFiles.toTypedArray())
+
       // Return the job's status
       return res.status
     }


### PR DESCRIPTION
### Description

In initial development, the step that appends the output files to the database record for jobs was never implemented.  This PR adds that functionality.

Resolves #24 

### Changes
- Add missing step to update db record with job output files.

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies