### PR TITLE
Fix issue #29

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.6.21"
-  id("org.jetbrains.dokka") version "1.6.21"
+  kotlin("jvm") version "1.8.0"
+  id("org.jetbrains.dokka") version "1.7.20"
   java
   `maven-publish`
 }
 
 group = "org.veupathdb.lib"
-version = "1.3.5"
+version = "1.3.6"
 
 repositories {
   mavenLocal()
@@ -29,13 +29,13 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
 
   // Jackson
-  implementation(platform("com.fasterxml.jackson:jackson-bom:2.13.4"))
+  implementation(platform("com.fasterxml.jackson:jackson-bom:2.14.2"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("org.veupathdb.lib:jackson-singleton:3.0.0")
 
   // DB
   implementation("com.zaxxer:HikariCP:5.0.1")
-  implementation("org.postgresql:postgresql:42.5.0")
+  implementation("org.postgresql:postgresql:42.5.1")
 
   // S3
   implementation("org.veupathdb.lib.s3:s34k-minio:0.3.6+s34k-0.7.2")

--- a/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
+++ b/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
@@ -72,6 +72,11 @@ internal object QueueDB {
     return ds!!.connection.use { GetExpiredJobs(it, cutoff) }
   }
 
+  @JvmStatic
+  fun markJobAsQueued(jobID: HashID, queue: String) {
+    Log.debug("Marking job {} as queued", jobID)
+    ds!!.connection.use { MarkJobQueued(it, jobID, queue) }
+  }
 
   /**
    * Marks the target job as expired in the database.
@@ -85,7 +90,6 @@ internal object QueueDB {
     Log.debug("Marking job {} as expired", jobID)
     ds!!.connection.use { MarkJobExpired(it, jobID) }
   }
-
 
   /**
    * Marks the target job as failed in the database.

--- a/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/update/queue-job.kt
+++ b/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/update/queue-job.kt
@@ -1,0 +1,31 @@
+package org.veupathdb.lib.compute.platform.intern.db.queries.update
+
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+
+private const val SQL = """
+  UPDATE
+    compute.jobs
+  SET
+    queue = ?
+  , status = 'queued'
+  WHERE
+    job_id = ?
+"""
+
+/**
+ * Resets the target job to queued in the database.
+ *
+ * @param con Open database connection to be used for the query.
+ *
+ * @param jobID Hash ID of the job to mark as expired.
+ *
+ * @param queue Name of the new queue the job was submitted to.
+ */
+internal fun MarkJobQueued(con: Connection, jobID: HashID, queue: String) {
+  con.prepareStatement(SQL).use { ps ->
+    ps.setBytes(1, jobID.bytes)
+    ps.setString(2, queue)
+    ps.execute()
+  }
+}

--- a/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/update/queue-job.kt
+++ b/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/update/queue-job.kt
@@ -24,8 +24,8 @@ private const val SQL = """
  */
 internal fun MarkJobQueued(con: Connection, jobID: HashID, queue: String) {
   con.prepareStatement(SQL).use { ps ->
-    ps.setBytes(1, jobID.bytes)
-    ps.setString(2, queue)
+    ps.setString(1, queue)
+    ps.setBytes(2, jobID.bytes)
     ps.execute()
   }
 }


### PR DESCRIPTION
### Description

Updates the job submission method to update a job back to the `queued` status when it already exists rather than attempting to insert it again.

### Changes
- fix described above
- update dependencies
- update Kotlin version (no code changes needed)
- library version bump

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies