### PR TITLE
Allow manual job expiration.

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.4.0"
+version = "1.5.0"
 
 
 dependencies {

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
@@ -274,7 +274,7 @@ object AsyncPlatform {
     // instance.
     (QueueDB.getJob(jobID)
       ?: throw IllegalStateException("Attempted to expire unowned job $jobID"))
-      .finished ?: throw IllegalStateException("Attempted to incomplete job $jobID")
+      .finished ?: throw IllegalStateException("Attempted expire to incomplete job $jobID")
 
     QueueDB.markJobAsExpired(jobID)
     S3.expireWorkspace(jobID)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
@@ -255,4 +255,28 @@ object AsyncPlatform {
 
     return ownedJobs.values.toTypedArray().asList()
   }
+
+  /**
+   * Marks the target job as expired.
+   *
+   * If the target job does not exist or is not owned by this platform instance,
+   * an [IllegalStateException] will be thrown.
+   *
+   * @param jobID ID of the job to expire.
+   *
+   * @since 1.5.0
+   */
+  @JvmStatic
+  fun expireJob(jobID: HashID) {
+    Log.debug("Expiring job {}", jobID)
+
+    // Verify that this job exists and is owned bt the current platform
+    // instance.
+    (QueueDB.getJob(jobID)
+      ?: throw IllegalStateException("Attempted to expire unowned job $jobID"))
+      .finished ?: throw IllegalStateException("Attempted to incomplete job $jobID")
+
+    QueueDB.markJobAsExpired(jobID)
+    S3.expireWorkspace(jobID)
+  }
 }

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
@@ -2,6 +2,8 @@ package org.veupathdb.lib.compute.platform
 
 import org.slf4j.LoggerFactory
 import org.veupathdb.lib.compute.platform.config.AsyncPlatformConfig
+import org.veupathdb.lib.compute.platform.errors.IncompleteJobException
+import org.veupathdb.lib.compute.platform.errors.UnownedJobException
 import org.veupathdb.lib.compute.platform.intern.JobPruner
 import org.veupathdb.lib.compute.platform.intern.db.DatabaseMigrator
 import org.veupathdb.lib.compute.platform.intern.db.QueueDB
@@ -225,8 +227,8 @@ object AsyncPlatform {
 
     // Assert that the job is both owned by this process and is complete
     (QueueDB.getJob(jobID)
-      ?: throw IllegalStateException("Attempted to delete unowned job $jobID"))
-      .finished ?: throw IllegalStateException("Attempted to delete incomplete job $jobID")
+      ?: throw UnownedJobException("Attempted to delete unowned job $jobID"))
+      .finished ?: throw IncompleteJobException("Attempted to delete incomplete job $jobID")
 
     QueueDB.deleteJob(jobID)
     S3.deleteWorkspace(jobID)
@@ -259,8 +261,11 @@ object AsyncPlatform {
   /**
    * Marks the target job as expired.
    *
-   * If the target job does not exist or is not owned by this platform instance,
-   * an [IllegalStateException] will be thrown.
+   * If the target job is not owned by the current Async Platform instance, an
+   * [UnownedJobException] will be thrown.
+   *
+   * If the target job is not yet in a 'finished' state (complete or failed), an
+   * [IncompleteJobException] will be thrown.
    *
    * @param jobID ID of the job to expire.
    *
@@ -273,8 +278,8 @@ object AsyncPlatform {
     // Verify that this job exists and is owned bt the current platform
     // instance.
     (QueueDB.getJob(jobID)
-      ?: throw IllegalStateException("Attempted to expire unowned job $jobID"))
-      .finished ?: throw IllegalStateException("Attempted expire to incomplete job $jobID")
+      ?: throw UnownedJobException("Attempted to expire unowned job $jobID"))
+      .finished ?: throw IncompleteJobException("Attempted expire to incomplete job $jobID")
 
     QueueDB.markJobAsExpired(jobID)
     S3.expireWorkspace(jobID)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/errors/IncompleteJobException.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/errors/IncompleteJobException.kt
@@ -1,0 +1,15 @@
+package org.veupathdb.lib.compute.platform.errors
+
+/**
+ * Exception thrown when attempting an illegal operation due to a job not yet
+ * being in a "finished" state (complete or failed).
+ */
+class IncompleteJobException : IllegalStateException {
+  constructor() : super()
+
+  constructor(message: String) : super(message)
+
+  constructor(cause: Throwable) : super(cause)
+
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/errors/UnownedJobException.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/errors/UnownedJobException.kt
@@ -1,0 +1,16 @@
+package org.veupathdb.lib.compute.platform.errors
+
+/**
+ * Exception thrown when attempting an illegal operation due to a job not being
+ * owned by the current Async Platform instance.
+ */
+class UnownedJobException : IllegalStateException {
+  constructor() : super()
+
+  constructor(message: String) : super(message)
+
+  constructor(cause: Throwable) : super(cause)
+
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}
+

--- a/readme.adoc
+++ b/readme.adoc
@@ -29,7 +29,7 @@ image::docs/assets/overview.png[]
 [source, kotlin]
 ----
 dependencies {
-  implementation("org.veupathdb.lib:compute-platform:1.2.2")
+  implementation("org.veupathdb.lib:compute-platform:1.5.0")
 }
 ----
 


### PR DESCRIPTION
### Description
Job expiration method.  This method allows manually expiring single jobs.

### Changes
- Adds a method to AsyncPlatform that allows for the manual expiration of individual jobs.
- premature version bump to 1.5.0 (other features will also be rolled into this new version)

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies