### PR TITLE
Workspace deletion/expiration checks when executing an async job.

### DIFF
--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/queues/QueueWrapper.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/queues/QueueWrapper.kt
@@ -9,7 +9,6 @@ import org.veupathdb.lib.compute.platform.intern.jobs.JobExecutors
 import org.veupathdb.lib.compute.platform.intern.metrics.JobMetrics
 import org.veupathdb.lib.compute.platform.intern.metrics.QueueMetrics
 import org.veupathdb.lib.compute.platform.intern.s3.S3
-import org.veupathdb.lib.compute.platform.job.JobResultStatus
 import org.veupathdb.lib.compute.platform.job.PlatformJobResultStatus
 import org.veupathdb.lib.hash_id.HashID
 import org.veupathdb.lib.rabbit.jobs.QueueConfig

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/queues/QueueWrapper.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/queues/QueueWrapper.kt
@@ -10,6 +10,7 @@ import org.veupathdb.lib.compute.platform.intern.metrics.JobMetrics
 import org.veupathdb.lib.compute.platform.intern.metrics.QueueMetrics
 import org.veupathdb.lib.compute.platform.intern.s3.S3
 import org.veupathdb.lib.compute.platform.job.JobResultStatus
+import org.veupathdb.lib.compute.platform.job.PlatformJobResultStatus
 import org.veupathdb.lib.hash_id.HashID
 import org.veupathdb.lib.rabbit.jobs.QueueConfig
 import org.veupathdb.lib.rabbit.jobs.QueueDispatcher
@@ -96,8 +97,9 @@ internal class QueueWrapper(conf: AsyncQueueConfig) {
       S3.markWorkspaceAsInProgress(job.jobID)
 
       when (JobExecutors.new(JobExecContext(name, job.jobID, job.body)).execute(job.jobID, job.body)) {
-        JobResultStatus.Success -> handler.sendSuccess(SuccessNotification(job.jobID))
-        JobResultStatus.Failure -> handler.sendError(ErrorNotification(job.jobID, 1))
+        PlatformJobResultStatus.Success -> handler.sendSuccess(SuccessNotification(job.jobID))
+        PlatformJobResultStatus.Failure -> handler.sendError(ErrorNotification(job.jobID, 1))
+        PlatformJobResultStatus.Aborted -> { /* Job was aborted, send no notifications. */ }
       }
     } catch (e: Throwable) {
       Log.error("job execution failed with an exception for job ${job.jobID}", e)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/job/PlatformJobResultStatus.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/job/PlatformJobResultStatus.kt
@@ -1,0 +1,13 @@
+package org.veupathdb.lib.compute.platform.job
+
+internal enum class PlatformJobResultStatus {
+  Success,
+  Failure,
+  Aborted,
+}
+
+internal fun JobResultStatus.toPlatformStatus() =
+  when (this) {
+    JobResultStatus.Success -> PlatformJobResultStatus.Success
+    JobResultStatus.Failure -> PlatformJobResultStatus.Failure
+  }


### PR DESCRIPTION
### Description

Adds checks to the async platform's job execution that ensure the job's workspace is in a valid state before the job is executed, after the job is executed but before anything is written to S3 (MinIO), and after the job's result files are written to S3 (MinIO).

If the workspace is found to be deleted or expired before the job is executed, the job will be "aborted" without execution.

If the workspace is found to be deleted or expired after the job is executed but before anything is written to S3 (MinIO) the
job will be "aborted" and nothing will be written to S3 (MinIO).

If the workspace is found to be invalid after the job's result files were written to S3 (MinIO) the workspace will be wiped entirely and the job will be "aborted".

"Aborted" in this context means to complete without the standard binary completion status of Success/Failure.  No completion notice is sent for an aborted job.


### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies