### PR TITLE
Do not halt startup for broken workspace on queued job recovery.

### DIFF
--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/errors/NonexistentWorkspaceException.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/errors/NonexistentWorkspaceException.kt
@@ -1,0 +1,28 @@
+package org.veupathdb.lib.compute.platform.errors
+
+import org.veupathdb.lib.hash_id.HashID
+
+class NonexistentWorkspaceException : IllegalStateException {
+
+  val jobID: HashID
+
+  constructor(jobID: HashID) : super(makeMessage(jobID)) {
+    this.jobID = jobID
+  }
+
+  constructor(jobID: HashID, message: String) : super(message) {
+    this.jobID = jobID
+  }
+
+  constructor(jobID: HashID, cause: Throwable) : super(makeMessage(jobID), cause) {
+    this.jobID = jobID
+  }
+
+  constructor(jobID: HashID, message: String, cause: Throwable) : super(message, cause) {
+    this.jobID = jobID
+  }
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun makeMessage(jobID: HashID) =
+  "expected workspace to exist for job $jobID, but it didn't"

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/S3.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/S3.kt
@@ -3,6 +3,7 @@ package org.veupathdb.lib.compute.platform.intern.s3
 import com.fasterxml.jackson.databind.JsonNode
 import org.slf4j.LoggerFactory
 import org.veupathdb.lib.compute.platform.config.AsyncS3Config
+import org.veupathdb.lib.compute.platform.errors.NonexistentWorkspaceException
 import org.veupathdb.lib.compute.platform.intern.*
 import org.veupathdb.lib.compute.platform.job.AsyncJob
 import org.veupathdb.lib.compute.platform.job.JobFileReference
@@ -258,7 +259,7 @@ internal object S3 {
   fun resetWorkspace(jobID: HashID) {
     Log.debug("Resetting workspace for job {} in S3", jobID)
 
-    val ws = wsf[jobID] ?: throw IllegalStateException("Attempted to reset nonexistent workspace $jobID")
+    val ws = wsf[jobID] ?: throw NonexistentWorkspaceException(jobID, "attempted to reset nonexistent workspace $jobID")
 
     // Iterate through the files in the workspace
     ws.files().forEach {


### PR DESCRIPTION
### Description

References: #45

This change should make it so when this issue is encountered going forward, we simply print an error log with the stacktrace and move on with the startup.

### Changes
- Create new error type for non-existent workspaces
- throw the new error in the reset workspace case
- catch the new error in the platform startup and log it

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies