### PR TITLE
move all combination DB+S3 operations behind a lock

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
 
   // Jackson
-  implementation(platform("com.fasterxml.jackson:jackson-bom:2.14.2"))
+  implementation(platform("com.fasterxml.jackson:jackson-bom:2.15.0"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("org.veupathdb.lib:jackson-singleton:3.0.0")
 

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/JobManager.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/JobManager.kt
@@ -1,0 +1,52 @@
+package org.veupathdb.lib.compute.platform
+
+import org.veupathdb.lib.compute.platform.intern.db.AsyncDBJob
+import org.veupathdb.lib.compute.platform.intern.db.QueueDB
+import org.veupathdb.lib.compute.platform.intern.s3.AsyncS3Job
+import org.veupathdb.lib.compute.platform.intern.s3.S3
+import org.veupathdb.lib.hash_id.HashID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+internal object JobManager {
+  private val lock = ReentrantLock()
+
+  fun getJob(jobID: HashID): Pair<AsyncDBJob?, AsyncS3Job?> {
+    return lock.withLock { QueueDB.getJob(jobID) to S3.getJob(jobID) }
+  }
+
+  fun setJobQueued(jobID: HashID, queue: String) {
+    lock.withLock {
+      QueueDB.markJobAsQueued(jobID, queue)
+      S3.markWorkspaceAsQueued(jobID)
+    }
+  }
+
+  fun setJobInProgress(jobID: HashID) {
+    lock.withLock {
+      QueueDB.markJobAsInProgress(jobID)
+      S3.markWorkspaceAsInProgress(jobID)
+    }
+  }
+
+  fun setJobComplete(jobID: HashID) {
+    lock.withLock {
+      QueueDB.markJobAsComplete(jobID)
+      S3.markWorkspaceAsComplete(jobID)
+    }
+  }
+
+  fun setJobFailed(jobID: HashID) {
+    lock.withLock {
+      QueueDB.markJobAsFailed(jobID)
+      S3.markWorkspaceAsFailed(jobID)
+    }
+  }
+
+  fun setJobExpired(jobID: HashID) {
+    lock.withLock {
+      QueueDB.markJobAsExpired(jobID)
+      S3.expireWorkspace(jobID)
+    }
+  }
+}

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/JobPruner.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/JobPruner.kt
@@ -1,6 +1,7 @@
 package org.veupathdb.lib.compute.platform.intern
 
 import org.slf4j.LoggerFactory
+import org.veupathdb.lib.compute.platform.JobManager
 import org.veupathdb.lib.compute.platform.config.AsyncPlatformConfig
 import org.veupathdb.lib.compute.platform.intern.db.QueueDB
 import org.veupathdb.lib.compute.platform.intern.s3.S3
@@ -34,10 +35,7 @@ internal object JobPruner : Runnable {
 
     Log.info("Found {} expired jobs", prunableJobs.size)
 
-    prunableJobs.forEach {
-      QueueDB.markJobAsExpired(it)
-      S3.expireWorkspace(it)
-    }
+    prunableJobs.forEach { JobManager.setJobExpired(it) }
 
     Log.info("Job pruning complete")
   }

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
@@ -185,7 +185,7 @@ internal object QueueDB {
    * @return The located job record, if it exists, otherwise `null`.
    */
   @JvmStatic
-  fun getJob(jobID: HashID) : AsyncJob? {
+  fun getJob(jobID: HashID) : AsyncDBJob? {
     Log.debug("looking up public job {}", jobID)
 
     return ds.connection.use {

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/S3.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/S3.kt
@@ -73,7 +73,7 @@ internal object S3 {
    * @return The target job, if a workspace for it exists, otherwise `null`.
    */
   @JvmStatic
-  fun getJob(jobID: HashID): AsyncJob? {
+  fun getJob(jobID: HashID): AsyncS3Job? {
     Log.debug("Fetching workspace {} from S3", jobID)
     return wsf[jobID]?.let(::XS3Workspace)?.let(::AsyncS3Job)
   }
@@ -288,6 +288,13 @@ internal object S3 {
 
     val ws = wsf[jobID] ?: throw IllegalStateException("Attempted to mark nonexistent workspace $jobID as in-progress")
     ws.touch(FlagInProgress)
+  }
+
+  fun markWorkspaceAsQueued(jobID: HashID) {
+    Log.debug("marking workspace for job {} as queued in S3", jobID)
+
+    val ws = wsf[jobID] ?: throw IllegalStateException("Attempted to mark nonexistent workspace $jobID as queued")
+    ws.touch(FlagQueued)
   }
 
   fun markWorkspaceAsFailed(jobID: HashID) {


### PR DESCRIPTION
### Description

Moves all lookup and status change operations behind a singular lock to prevent the race condition where a status change could happen between looking up the DB record and looking up the S3 record.  This does not prevent the race condition from happening cross campus, if something has gone wrong where both campuses are operating on the same job.

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies