### PR TITLE
Expose internal job records for admin endpoints

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.6.2"
+version = "1.7.0"
 
 
 dependencies {

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/AsyncPlatform.kt
@@ -7,6 +7,7 @@ import org.veupathdb.lib.compute.platform.intern.JobPruner
 import org.veupathdb.lib.compute.platform.intern.db.AsyncDBJob
 import org.veupathdb.lib.compute.platform.intern.db.DatabaseMigrator
 import org.veupathdb.lib.compute.platform.intern.db.QueueDB
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.intern.jobs.JobExecutors
 import org.veupathdb.lib.compute.platform.intern.queues.JobQueues
 import org.veupathdb.lib.compute.platform.intern.s3.S3
@@ -320,6 +321,26 @@ object AsyncPlatform {
       .forEach { ownedJobs[it.jobID] = it }
 
     return ownedJobs.values.toTypedArray().asList()
+  }
+
+  /**
+   * Look up the given Job ID in the internal QueueDB and return it if present.
+   *
+   * @return Internal job record if it exists in the internal QueueDB.
+   */
+  @JvmStatic
+  fun getJobInternal(jobID: HashID): InternalJobRecord? {
+    return QueueDB.getJobInternal(jobID)
+  }
+
+  /**
+   * Looks up all jobs available in the Queue.
+   *
+   * @return Internal job record if it exists in the internal QueueDB.
+   */
+  @JvmStatic
+  fun listJobsInternal(): List<InternalJobRecord> {
+    return QueueDB.getAllJobs().toList()
   }
 
   /**

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/AsyncDBJob.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/AsyncDBJob.kt
@@ -1,10 +1,10 @@
 package org.veupathdb.lib.compute.platform.intern.db
 
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.job.AsyncJob
 
 internal class AsyncDBJob(
-  private val raw: JobRecord,
+  private val raw: InternalJobRecord,
   override val queuePosition: Int?
 ) : AsyncJob {
   override val jobID

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/QueueDB.kt
@@ -5,12 +5,11 @@ import com.zaxxer.hikari.HikariDataSource
 import org.postgresql.Driver
 import org.slf4j.LoggerFactory
 import org.veupathdb.lib.compute.platform.config.AsyncPlatformConfig
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.intern.db.queries.delete.DeleteJob
 import org.veupathdb.lib.compute.platform.intern.db.queries.insert.RecordNewJob
 import org.veupathdb.lib.compute.platform.intern.db.queries.select.*
 import org.veupathdb.lib.compute.platform.intern.db.queries.update.*
-import org.veupathdb.lib.compute.platform.job.AsyncJob
 import org.veupathdb.lib.compute.platform.job.JobStatus
 import org.veupathdb.lib.hash_id.HashID
 import java.time.OffsetDateTime
@@ -203,7 +202,7 @@ internal object QueueDB {
   }
 
   @JvmStatic
-  fun getJobInternal(jobID: HashID): JobRecord? {
+  fun getJobInternal(jobID: HashID): InternalJobRecord? {
     Log.debug("looking up raw job {}", jobID)
     return ds.connection.use { LookupJob(it, jobID) }
   }
@@ -223,7 +222,7 @@ internal object QueueDB {
    *
    * @return Stream of queued jobs ordered by job creation date.
    */
-  fun getQueuedJobs(): Stream<JobRecord> {
+  fun getQueuedJobs(): Stream<InternalJobRecord> {
     Log.debug("Getting list of queued jobs.")
 
     // Connection is not closed here as the caller is responsible for closing
@@ -239,7 +238,7 @@ internal object QueueDB {
    *
    * @return Stream of queued jobs ordered by job creation date.
    */
-  fun getRunningJobs(): Stream<JobRecord> {
+  fun getRunningJobs(): Stream<InternalJobRecord> {
     Log.debug("Getting list of queued jobs.")
 
     // Connection is not closed here as the caller is responsible for closing
@@ -255,7 +254,7 @@ internal object QueueDB {
    *
    * @return Stream of queued jobs ordered by job creation date.
    */
-  fun getFailedJobs(): Stream<JobRecord> {
+  fun getFailedJobs(): Stream<InternalJobRecord> {
     Log.debug("Getting list of queued jobs.")
 
     // Connection is not closed here as the caller is responsible for closing
@@ -272,7 +271,7 @@ internal object QueueDB {
    *
    * @since 1.4.0
    */
-  fun getAllJobs(): Stream<JobRecord> {
+  fun getAllJobs(): Stream<InternalJobRecord> {
     Log.debug("Getting list of all jobs.")
 
     // Connection is not closed here as the caller is responsible for closing

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-all-jobs.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-all-jobs.kt
@@ -1,6 +1,6 @@
 package org.veupathdb.lib.compute.platform.intern.db.queries.select
 
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.intern.db.util.stream
 import java.sql.Connection
 import java.sql.ResultSet
@@ -38,7 +38,7 @@ private const val SQL = """
  * **WARNING**: The returned stream **MUST** be closed on completion to avoid DB
  * connection leaks.
  */
-internal fun ListAllJobs(con: Connection): Stream<JobRecord> {
+internal fun ListAllJobs(con: Connection): Stream<InternalJobRecord> {
   // Nothing is closed in this method as the caller is responsible for closing
   // the returned stream (which will close the connection, statement, and
   // result-set)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-failed-jobs.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-failed-jobs.kt
@@ -1,6 +1,6 @@
 package org.veupathdb.lib.compute.platform.intern.db.queries.select
 
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.intern.db.util.stream
 import java.sql.Connection
 import java.sql.ResultSet
@@ -39,7 +39,7 @@ private const val SQL = """
  * **WARNING**: The returned stream **MUST** be closed on completion to avoid DB
  * connection leaks.
  */
-internal fun ListFailedJobs(con: Connection): Stream<JobRecord> {
+internal fun ListFailedJobs(con: Connection): Stream<InternalJobRecord> {
   // Nothing is closed in this method as the caller is responsible for closing
   // the returned stream (which will close the connection, statement, and
   // result-set)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-queued-jobs.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-queued-jobs.kt
@@ -1,6 +1,6 @@
 package org.veupathdb.lib.compute.platform.intern.db.queries.select
 
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.intern.db.util.stream
 import java.sql.Connection
 import java.sql.ResultSet
@@ -39,7 +39,7 @@ private const val SQL = """
  * **WARNING**: The returned stream **MUST** be closed on completion to avoid DB
  * connection leaks.
  */
-internal fun ListQueuedJobs(con: Connection): Stream<JobRecord> {
+internal fun ListQueuedJobs(con: Connection): Stream<InternalJobRecord> {
   // Nothing is closed in this method as the caller is responsible for closing
   // the returned stream (which will close the connection, statement, and
   // result-set)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-running-jobs.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/list-running-jobs.kt
@@ -1,6 +1,6 @@
 package org.veupathdb.lib.compute.platform.intern.db.queries.select
 
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.intern.db.util.stream
 import java.sql.Connection
 import java.sql.ResultSet
@@ -39,7 +39,7 @@ private const val SQL = """
  * **WARNING**: The returned stream **MUST** be closed on completion to avoid DB
  * connection leaks.
  */
-internal fun ListRunningJobs(con: Connection): Stream<JobRecord> {
+internal fun ListRunningJobs(con: Connection): Stream<InternalJobRecord> {
   // Nothing is closed in this method as the caller is responsible for closing
   // the returned stream (which will close the connection, statement, and
   // result-set)

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/util-job-table.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/queries/select/util-job-table.kt
@@ -1,6 +1,6 @@
 package org.veupathdb.lib.compute.platform.intern.db.queries.select
 
-import org.veupathdb.lib.compute.platform.intern.db.model.JobRecord
+import org.veupathdb.lib.compute.platform.job.InternalJobRecord
 import org.veupathdb.lib.compute.platform.job.JobStatus
 import org.veupathdb.lib.hash_id.HashID
 import org.veupathdb.lib.jackson.Json
@@ -8,7 +8,7 @@ import java.sql.ResultSet
 import java.time.OffsetDateTime
 
 internal fun ResultSet.toJobRow() =
-  JobRecord(
+  InternalJobRecord(
     HashID(getBytes(1)),                         // job_id
     JobStatus.fromString(getString(2)),          // status
     getString(3),                                // queue

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/job/InternalJobRecord.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/job/InternalJobRecord.kt
@@ -1,7 +1,6 @@
-package org.veupathdb.lib.compute.platform.intern.db.model
+package org.veupathdb.lib.compute.platform.job
 
 import com.fasterxml.jackson.databind.JsonNode
-import org.veupathdb.lib.compute.platform.job.JobStatus
 import org.veupathdb.lib.hash_id.HashID
 import java.time.OffsetDateTime
 
@@ -13,7 +12,7 @@ import java.time.OffsetDateTime
  * @author Elizabeth Paige Harper [https://github.com/foxcapades]
  * @since 1.0.0
  *
- * @constructor Creates a new [JobRecord] instance.
+ * @constructor Creates a new [InternalJobRecord] instance.
  *
  * @param jobID Hash ID of the job this record represents.
  *
@@ -41,7 +40,7 @@ import java.time.OffsetDateTime
  *
  * This will be `null` if the job has not yet finished.
  */
-internal class JobRecord (
+class InternalJobRecord (
   val jobID:         HashID,
   val status:        JobStatus,
   val queue:         String,


### PR DESCRIPTION
### Description
Add an API for internal jobs to enable debugging of QueueDB.

### Changes
- Made JobRecord public and renamed it
- Added two new methods to async platform

### PR Checklist
* [X] Updated relevant source docs
* [X] Updated readme / docs
* [X] Updated dependencies