### PR TITLE
Fix race condition in status job status checking

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
 
   // Misc & Utils
   api("org.veupathdb.lib:hash-id:1.1.0")
+  implementation("com.github.ben-manes.caffeine:caffeine:3.1.8") // Used for self-expiring cache.
 
   // Testing
   testImplementation(kotlin("test"))

--- a/lib/src/main/kotlin/module-info.java
+++ b/lib/src/main/kotlin/module-info.java
@@ -19,5 +19,6 @@ module veupath.compute.platform {
   requires rabbit.job.queue;
   requires workspaces;
   requires jackson.singleton;
+  requires com.github.benmanes.caffeine;
 
 }

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/JobManager.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/JobManager.kt
@@ -16,7 +16,7 @@ import kotlin.concurrent.withLock
 internal object JobManager {
   private val Log = LoggerFactory.getLogger(javaClass)
   private val LocksByJobID: Cache<String, ReentrantLock> = Caffeine.newBuilder()
-    .expireAfterWrite(30L, TimeUnit.MINUTES)
+    .expireAfterWrite(30L, TimeUnit.MINUTES) // Expire after 30 minutes to free up memory.
     .build()
 
   fun getJob(jobID: HashID): Pair<AsyncDBJob?, AsyncS3Job?> {

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/JobManager.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/JobManager.kt
@@ -1,21 +1,64 @@
 package org.veupathdb.lib.compute.platform
 
+import org.slf4j.LoggerFactory
 import org.veupathdb.lib.compute.platform.intern.db.AsyncDBJob
 import org.veupathdb.lib.compute.platform.intern.db.QueueDB
 import org.veupathdb.lib.compute.platform.intern.s3.AsyncS3Job
 import org.veupathdb.lib.compute.platform.intern.s3.S3
+import org.veupathdb.lib.compute.platform.job.AsyncJob
 import org.veupathdb.lib.hash_id.HashID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 internal object JobManager {
-  private val lock = ReentrantLock()
+  private val Log = LoggerFactory.getLogger(javaClass)
+  private val LocksByJobID = ConcurrentHashMap<String, ReentrantLock>()
 
   fun getJob(jobID: HashID): Pair<AsyncDBJob?, AsyncS3Job?> {
+    val lock = ensureLock(jobID)
     return lock.withLock { QueueDB.getJob(jobID) to S3.getJob(jobID) }
   }
 
+  fun getAndReconcileJob(jobID: HashID): AsyncJob? {
+    val (dbJob, s3Job) = getJob(jobID)
+    val lock = ensureLock(jobID)
+    if (dbJob != null) {
+      Log.debug("job {} found in the managed database", jobID)
+
+      // If the status as determined by looking at S3 does not align with the
+      // status we last knew in our internal database, then another campus has
+      // claimed ownership of the job.
+      if (lock.withLock { s3Job != null && s3Job.status != dbJob.status }) { // Lock while checking lazy initialized statuses to ensure nothing changes from under us.
+        Log.debug("deleting job {} from queue db as it has a different status in S3 than the queue DB: s3.status = {}, db.status = {}", jobID, s3Job?.status, dbJob.status)
+
+        // Delete our DB record for the job and return the S3 instance instead.
+        QueueDB.deleteJob(jobID)
+        return s3Job
+      }
+
+      // The statuses did align, so we (this service instance) presumably still
+      // own the job.
+
+      Log.debug("updating last accessed date for job {}", jobID)
+
+      // update it's last accessed date
+      QueueDB.updateJobLastAccessed(jobID)
+      // and return it
+      return dbJob
+    }
+
+    if (s3Job != null) {
+      Log.debug("job {} found in S3", jobID)
+      // return it
+      return s3Job
+    }
+
+    return null;
+  }
+
   fun setJobQueued(jobID: HashID, queue: String) {
+    val lock = ensureLock(jobID)
     lock.withLock {
       QueueDB.markJobAsQueued(jobID, queue)
       S3.markWorkspaceAsQueued(jobID)
@@ -23,6 +66,7 @@ internal object JobManager {
   }
 
   fun setJobInProgress(jobID: HashID) {
+    val lock = ensureLock(jobID)
     lock.withLock {
       QueueDB.markJobAsInProgress(jobID)
       S3.markWorkspaceAsInProgress(jobID)
@@ -30,6 +74,7 @@ internal object JobManager {
   }
 
   fun setJobComplete(jobID: HashID) {
+    val lock = ensureLock(jobID)
     lock.withLock {
       QueueDB.markJobAsComplete(jobID)
       S3.markWorkspaceAsComplete(jobID)
@@ -37,6 +82,7 @@ internal object JobManager {
   }
 
   fun setJobFailed(jobID: HashID) {
+    val lock = ensureLock(jobID)
     lock.withLock {
       QueueDB.markJobAsFailed(jobID)
       S3.markWorkspaceAsFailed(jobID)
@@ -44,9 +90,14 @@ internal object JobManager {
   }
 
   fun setJobExpired(jobID: HashID) {
+    val lock = ensureLock(jobID)
     lock.withLock {
       QueueDB.markJobAsExpired(jobID)
       S3.expireWorkspace(jobID)
     }
+  }
+
+  private fun ensureLock(jobID: HashID): ReentrantLock {
+    return LocksByJobID.computeIfAbsent(jobID.string) { ReentrantLock() }
   }
 }

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/AsyncDBJob.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/db/AsyncDBJob.kt
@@ -10,8 +10,7 @@ internal class AsyncDBJob(
   override val jobID
     get() = raw.jobID
 
-  override val status
-    get() = raw.status
+  override val status by lazy { QueueDB.getJobInternal(jobID)!!.status }
 
   override val owned = true
 

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/AsyncS3Job.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/AsyncS3Job.kt
@@ -7,8 +7,8 @@ internal class AsyncS3Job(private val raw: XS3Workspace) : AsyncJob {
   override val jobID: HashID
     get() = raw.id
 
-  override val status = raw.deriveStatus()
-
+  override val status by lazy { raw.deriveStatus() }
+  
   override val queuePosition = null
 
   override val owned = false

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/AsyncS3Job.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/AsyncS3Job.kt
@@ -7,7 +7,7 @@ internal class AsyncS3Job(private val raw: XS3Workspace) : AsyncJob {
   override val jobID: HashID
     get() = raw.id
 
-  override val status by lazy { raw.deriveStatus() }
+  override val status = raw.deriveStatus()
 
   override val queuePosition = null
 

--- a/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/S3.kt
+++ b/lib/src/main/kotlin/org/veupathdb/lib/compute/platform/intern/s3/S3.kt
@@ -120,6 +120,7 @@ internal object S3 {
   @JvmStatic
   @JvmOverloads
   fun deleteWorkspace(jobID: HashID, throwOnNotExists: Boolean = true) {
+    Log.info("Deleting workspace with ID {}.", jobID)
     val ws = wsf[jobID]
 
     if (ws == null && throwOnNotExists) {


### PR DESCRIPTION
### Description
* I ended up making the status lazily initialized for S3 and QueueDB and added synchronization while loading the statuses
* I also allow expiration of remotely owned jobs which should be fine once the status synchronization is fixed.

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies