### PR TITLE
Handle jobs if they're only in postgres, not in S3

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.7.1"
+version = "1.7.2"
 
 
 dependencies {


### PR DESCRIPTION
### Description
A job got stuck in this state after we got a 500 from MinIO: see https://github.com/VEuPathDB/service-eda-compute/issues/88

### Changes
- Adds handling to JobManager for jobs deleted from MinIO.

### PR Checklist
* [X] Updated relevant source docs
* [X] Updated readme / docs
* [X] Updated dependencies