### PR TITLE
Message ack timeout

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   implementation("org.veupathdb.lib:jackson-singleton:3.1.1")
 
   // DB
-  implementation("com.zaxxer:HikariCP:5.0.1")
+  implementation("com.zaxxer:HikariCP:5.1.0")
   implementation("org.postgresql:postgresql:42.7.3")
 
   // S3
@@ -31,7 +31,7 @@ dependencies {
   api("org.veupathdb.lib.s3:workspaces:4.1.2")
 
   // Rabbit
-  implementation("org.veupathdb.lib:rabbit-job-queue:1.2.1")
+  implementation("org.veupathdb.lib:rabbit-job-queue:2.0.0")
 
   // Metrics
   implementation("io.prometheus:simpleclient:0.16.0")

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.7.5"
+version = "1.8.0"
 
 
 dependencies {

--- a/readme.adoc
+++ b/readme.adoc
@@ -29,7 +29,7 @@ image::docs/assets/overview.png[]
 [source, kotlin]
 ----
 dependencies {
-  implementation("org.veupathdb.lib:compute-platform:1.6.1")
+  implementation("org.veupathdb.lib:compute-platform:1.8.0")
 }
 ----
 

--- a/test/docker-compose.test.yml
+++ b/test/docker-compose.test.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD: password
 
   rabbit:
-    image: rabbitmq:3.11.10-management-alpine
+    image: rabbitmq:3.13.3-management-alpine
     ports:
     - "5672:5672"
 


### PR DESCRIPTION
### Description

Update compute platform to use the new rabbitmq wrapper lib version which enables automatic channel reconnects and message ack timeout config.

Closes #58 


### Changes
- Add new queue config option which will enable services to specify rabbitmq message ack timeouts greater than RabbitMQ's default value of 30 min
- Fix test script

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies