### PR TITLE
MinIO object deletion bandaid

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.8.1"
+version = "1.8.2"
 
 
 dependencies {

--- a/readme.adoc
+++ b/readme.adoc
@@ -29,7 +29,7 @@ image::docs/assets/overview.png[]
 [source, kotlin]
 ----
 dependencies {
-  implementation("org.veupathdb.lib:compute-platform:1.8.1")
+  implementation("org.veupathdb.lib:compute-platform:1.8.2")
 }
 ----
 


### PR DESCRIPTION
### Description

Apply a (hopefully) temporary fix for the MinIO object deletion bug.

### Changes
- Adds a new private method that sleeps for at most 1.5 seconds waiting for an object to be deleted, logging an error if it hasn't happened within that time frame.

### PR Checklist
* [x] Updated relevant source docs
* [x] Updated readme / docs
* [x] Updated dependencies